### PR TITLE
Feature: Remove lodash import

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ export const VueHammer = {
         that.config[event] = {}
 
         const direction = binding.modifiers
-        if (Object.keys(direction)) {
+        if (Object.keys(direction).length) {
           Object.keys(direction).map(keyName => {
             that.config[event].direction = String(keyName)
           })

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 import Hammer from 'hammerjs'
-import { isEmpty } from 'lodash'
 
 const gestures = ['tap', 'pan', 'pinch', 'press', 'rotate', 'swipe', 'doubletap']
 const directions = ['up', 'down', 'left', 'right', 'horizontal', 'vertical', 'all']

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ export const VueHammer = {
         that.config[event] = {}
 
         const direction = binding.modifiers
-        if (!isEmpty(direction)) {
+        if (Object.keys(direction)) {
           Object.keys(direction).map(keyName => {
             that.config[event].direction = String(keyName)
           })


### PR DESCRIPTION
Before, the `vue2-hammer` library was using `isEmpty` from `lodash` for one `if` check. Due to how it was imported, the full `lodash` library was being unnecessarily imported. 

I initially thought about changing the import to `import isEmpty from 'lodash.isEmpty` to make the dependency import smaller, but then I realized I could do without the dependency at all.

This PR removes the `lodash` import and instead uses `Object.keys(direction).length` for the `if` check. No dependency needed. 😉 